### PR TITLE
feat future: use fsm approach for implementing shared state for syncing

### DIFF
--- a/dsac/include/dsac/concurrency/futures/state.hpp
+++ b/dsac/include/dsac/concurrency/futures/state.hpp
@@ -13,16 +13,16 @@ namespace detail {
 
 enum class state : uint8_t { start = 1 << 0, only_result = 1 << 1, only_callback = 1 << 2, done = 1 << 3 };
 
-constexpr state operator&(state a, state b) noexcept {
+constexpr inline state operator&(state a, state b) noexcept {
   return static_cast<state>(static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
 }
-constexpr state operator|(state a, state b) noexcept {
+constexpr inline state operator|(state a, state b) noexcept {
   return static_cast<state>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
 }
-constexpr state operator^(state a, state b) noexcept {
+constexpr inline state operator^(state a, state b) noexcept {
   return static_cast<state>(static_cast<uint8_t>(a) ^ static_cast<uint8_t>(b));
 }
-constexpr state operator~(state a) noexcept {
+constexpr inline state operator~(state a) noexcept {
   return static_cast<state>(~static_cast<uint8_t>(a));
 }
 
@@ -31,13 +31,6 @@ constexpr state operator~(state a) noexcept {
 class shared_state_exception : public std::logic_error {
 public:
   using std::logic_error::logic_error;
-};
-
-class shared_state_already_satisfied : public shared_state_exception {
-public:
-  shared_state_already_satisfied()
-    : shared_state_exception("Shared state already satisfied") {
-  }
 };
 
 class shared_state_unexpected_state : public shared_state_exception {
@@ -150,39 +143,18 @@ private:
       \brief
           Perform dsac::result processing in a user-specified callback.
   */
-  void do_callback(callback<T>&& callback);
-
   void do_callback();
-
-  /*!
-      \brief
-          Check if shared state already initialized by dsac::result then throw.
-  */
-  void throw_if_fulfilled_by_result();
-
-  /*!
-      \brief
-          Check if shared state already initialized by dsac::callback then throw.
-  */
-  void throw_if_fulfilled_by_callback();
-
-  /*!
-      \brief
-          Value of shared state.
-  */
-  using state_value = std::variant<result<T>, callback<T>>;
-
-  /// A place to store user data or user-specified callback
-  mvar_ref<state_value> storage_;
-
-  /// A synchronization primitive to provide blocking data waiting in storage_
-  mvar<void> has_value_;
 
   /// User-specified environment for execution callback<T> from storage_
   executor_base_ref executor_;
 
+  /// Data storage space
   std::optional<result<T>> result_;
+
+  /// User-specified callback for executing when result_ will be initialized
   std::optional<callback<T>> callback_;
+
+  /// A current state of shared state
   std::atomic<detail::state> state_;
 };
 

--- a/dsac/include/dsac/concurrency/synchronization/mvar.hpp
+++ b/dsac/include/dsac/concurrency/synchronization/mvar.hpp
@@ -55,18 +55,6 @@ public:
     has_value_storage_.wait(lock, [this] { return storage_.has_value(); });
     return storage_.value();
   }
-
-  template <class Function>
-  auto try_with_lock(Function&& function) -> std::optional<typename std::result_of<Function(T const&)>::type> {
-    using return_type = typename std::result_of<Function(T const&)>::type;
-
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (!storage_.has_value()) {
-      return std::nullopt;
-    }
-
-    return std::optional<return_type>(function(storage_.value()));
-  }
 };
 
 template <>


### PR DESCRIPTION
The current implementation of the shared state for future/promise has a dead lock when we try to initialize a `dsac::result<T>` data. The idea for new implementation was taken from [folly](https://github.com/facebook/folly) project which was designed and implemented using fsm approach.